### PR TITLE
FIX: Allow repeat use of CheckSuite.

### DIFF
--- a/src/CheckSuite.php
+++ b/src/CheckSuite.php
@@ -46,6 +46,10 @@ class CheckSuite
      */
     public function run(callable $checkCallback = null)
     {
+        // Reset internal data collation; important if the suite is being used more than once
+        $this->setPoints(0);
+        $this->setCheckDetails([]);
+
         if (!$this->getChecks()) {
             throw new Exception('No checks have been defined! Please set some in config.yml.');
         }


### PR DESCRIPTION
This fix is necessary because the addons site uses CheckSuite as a reusable service.