### PR TITLE
FIX: Further fix to check resetting

### DIFF
--- a/src/CheckSuite.php
+++ b/src/CheckSuite.php
@@ -49,6 +49,7 @@ class CheckSuite
         // Reset internal data collation; important if the suite is being used more than once
         $this->setPoints(0);
         $this->setCheckDetails([]);
+        $this->checks = null; // setChecks can't be used as it expects array
 
         if (!$this->getChecks()) {
             throw new Exception('No checks have been defined! Please set some in config.yml.');


### PR DESCRIPTION
The Check objects need to be recreated as they also have internal state.

As an aside, putting caching / persistent data through all the layers
of an app makes these kind of bugs more necessary. It can be helpful,
instead, to keep most internal layers of a system quite “functional”
and not persist state, and then deal with whatever caching/persistence
is needed to get a performant result only on the outermost layers.